### PR TITLE
feat: add support for publishing events async

### DIFF
--- a/.github/workflows/specs.yaml
+++ b/.github/workflows/specs.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
+        os: [ubuntu]
         ruby: [2.5, 2.6, 2.7]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ It is very easy to create a new domain event and deliver it to multiple destinat
   OrderPlaced.publish(order_id: 1, time: Time.now)
   ```
 
+  Also you can publish the event async:
+
+  ```ruby
+  OrderPlaced.publish_async(order_id: 1, time: Time.now)
+  ```
+
 And your are done! 🎉
 
 An event can also define multiple destinations and each destination can have different set of options:

--- a/lib/event_router.rb
+++ b/lib/event_router.rb
@@ -17,6 +17,10 @@ module EventRouter
     EventRouter::Publisher.publish(events, adapter: adapter)
   end
 
+  def publish_async(events, adapter: EventRouter.configuration.delivery_adapter)
+    EventRouter::Publisher.publish_async(events, adapter: adapter)
+  end
+
   def serialize(event, adapter: EventRouter.configuration.serializer_adapter)
     EventRouter::Serializer.serialize(event, adapter: adapter)
   end

--- a/lib/event_router/delivery_adapters/base.rb
+++ b/lib/event_router/delivery_adapters/base.rb
@@ -21,6 +21,10 @@ module EventRouter
         def deliver(_event)
           raise NotImplementedError, "deliver method is not implemented for #{name}"
         end
+
+        def deliver_async(_event)
+          raise NotImplementedError, "deliver_async method is not implemented for #{name}"
+        end
       end
     end
   end

--- a/lib/event_router/delivery_adapters/helpers/deliver.rb
+++ b/lib/event_router/delivery_adapters/helpers/deliver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module EventRouter
+  module DeliveryAdapters
+    module Helpers
+      module Deliver
+        module_function
+
+        def yield_destinations(event)
+          event.destinations.each do |destination_name, destination|
+            if destination.prefetch_payload?
+              payload             = destination.extra_payload(event)
+              serialized_payload  = EventRouter.serialize(payload)
+            end
+
+            yield destination_name, serialized_payload
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/event_router/delivery_adapters/helpers/deliver.rb
+++ b/lib/event_router/delivery_adapters/helpers/deliver.rb
@@ -7,13 +7,13 @@ module EventRouter
         module_function
 
         def yield_destinations(event)
-          event.destinations.each do |destination_name, destination|
+          event.destinations.each do |_name, destination|
             if destination.prefetch_payload?
               payload             = destination.extra_payload(event)
               serialized_payload  = EventRouter.serialize(payload)
             end
 
-            yield destination_name, serialized_payload
+            yield destination, serialized_payload
           end
         end
       end

--- a/lib/event_router/delivery_adapters/helpers/sidekiq.rb
+++ b/lib/event_router/delivery_adapters/helpers/sidekiq.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module EventRouter
+  module DeliveryAdapters
+    module Helpers
+      module Sidekiq
+        module_function
+
+        def process_event(event, serialized_event: nil)
+          serialized_event ||= EventRouter.serialize(event)
+
+          options = EventRouter::DeliveryAdapters::Sidekiq.options
+
+          Helpers::Deliver.yield_destinations(event) do |destination_name, serialized_payload|
+            Workers::SidekiqDestinationDeliveryWorker
+              .set(queue: options[:queue], retry: options[:retry])
+              .perform_async(destination_name, serialized_event, serialized_payload)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/event_router/delivery_adapters/helpers/sidekiq.rb
+++ b/lib/event_router/delivery_adapters/helpers/sidekiq.rb
@@ -11,10 +11,10 @@ module EventRouter
 
           options = EventRouter::DeliveryAdapters::Sidekiq.options
 
-          Helpers::Deliver.yield_destinations(event) do |destination_name, serialized_payload|
+          Helpers::Deliver.yield_destinations(event) do |destination, serialized_payload|
             Workers::SidekiqDestinationDeliveryWorker
               .set(queue: options[:queue], retry: options[:retry])
-              .perform_async(destination_name, serialized_event, serialized_payload)
+              .perform_async(destination.name, serialized_event, serialized_payload)
           end
         end
       end

--- a/lib/event_router/delivery_adapters/sync.rb
+++ b/lib/event_router/delivery_adapters/sync.rb
@@ -3,11 +3,17 @@
 module EventRouter
   module DeliveryAdapters
     class Sync < Base
-      def self.deliver(event)
-        event.destinations.each do |_name, destination|
-          payload = destination.extra_payload(event)
+      class << self
+        def deliver(event)
+          event.destinations.each do |_name, destination|
+            payload = destination.extra_payload(event)
 
-          destination.process(event, payload)
+            destination.process(event, payload)
+          end
+        end
+
+        def deliver_async(event)
+          Thread.new { deliver(event) }
         end
       end
     end

--- a/lib/event_router/delivery_adapters/workers/sidekiq_destination_delivery_worker.rb
+++ b/lib/event_router/delivery_adapters/workers/sidekiq_destination_delivery_worker.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-require_relative '../../serializer'
-require 'sidekiq'
-
 module EventRouter
   module DeliveryAdapters
-    module Jobs
-      class SidekiqEventDeliveryJob
+    module Workers
+      class SidekiqDestinationDeliveryWorker
         include ::Sidekiq::Worker
 
         def perform(destination_name, serialized_event, serialized_payload)

--- a/lib/event_router/delivery_adapters/workers/sidekiq_event_delivery_worker.rb
+++ b/lib/event_router/delivery_adapters/workers/sidekiq_event_delivery_worker.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module EventRouter
+  module DeliveryAdapters
+    module Workers
+      class SidekiqEventDeliveryWorker
+        include ::Sidekiq::Worker
+
+        def perform(serialized_event)
+          event = EventRouter.deserialize(serialized_event)
+
+          Helpers::Sidekiq.process_event(event, serialized_event: serialized_event)
+        end
+      end
+    end
+  end
+end

--- a/lib/event_router/event.rb
+++ b/lib/event_router/event.rb
@@ -48,6 +48,10 @@ module EventRouter
       def publish(**attrs)
         EventRouter.publish(new(**attrs))
       end
+
+      def publish_async(**attrs)
+        EventRouter.publish_async(new(**attrs))
+      end
     end
   end
 end

--- a/lib/event_router/publisher.rb
+++ b/lib/event_router/publisher.rb
@@ -15,6 +15,12 @@ module EventRouter
       Array(events).each { |event| adapter_class.deliver(event) }
     end
 
+    def publish_async(events, adapter:)
+      adapter_class = delivery_adapter(adapter)
+
+      Array(events).each { |event| adapter_class.deliver_async(event) }
+    end
+
     def delivery_adapter(adapter)
       EventRouter.configuration.delivery_adapter_class(adapter)
     end

--- a/spec/event_router/delivery_adapters/sidekiq_spec.rb
+++ b/spec/event_router/delivery_adapters/sidekiq_spec.rb
@@ -1,18 +1,17 @@
 require 'event_router/delivery_adapters/sidekiq'
 
 RSpec.describe EventRouter::DeliveryAdapters::Sidekiq do
+  let(:event)             { DummyEvent.new }
+  let(:serialized_event)  { EventRouter.serialize(event) }
+  let(:adapter_options)   { { queue: :default, retry: 1 } }
+
+  before { allow(described_class).to receive(:options) { adapter_options } }
+
   describe '.deliver' do
     subject { described_class.deliver(event) }
 
-    let(:event)                           { DummyEvent.new }
-    let(:serialized_event)                { EventRouter.serialize(event) }
-    let(:adapter_options)                 { { queue: :default, retry: 1 } }
     let(:enabled_prefetch_destinations)   { event.destinations.select { |_k, v| v.prefetch_payload? } }
     let(:disabled_prefetch_destinations)  { event.destinations.reject { |_k, v| v.prefetch_payload? } }
-
-    before do
-      allow(described_class).to receive(:options) { adapter_options }
-    end
 
     it 'schedules one worker per destination' do
       enabled_prefetch_destinations.each do |name, destination|
@@ -36,6 +35,23 @@ RSpec.describe EventRouter::DeliveryAdapters::Sidekiq do
             :retry => adapter_options[:retry]
           )
       end
+
+      subject
+    end
+  end
+
+  describe '.deliver_async' do
+    subject { described_class.deliver_async(event) }
+
+    it 'schedules one worker to publish the event' do
+      expect(EventRouter::DeliveryAdapters::Workers::SidekiqEventDeliveryWorker).to receive(:client_push)
+        .once
+        .with(
+          'args' => [serialized_event],
+          'class' => EventRouter::DeliveryAdapters::Workers::SidekiqEventDeliveryWorker,
+          :queue => adapter_options[:queue],
+          :retry => adapter_options[:retry]
+        )
 
       subject
     end

--- a/spec/event_router/delivery_adapters/sidekiq_spec.rb
+++ b/spec/event_router/delivery_adapters/sidekiq_spec.rb
@@ -18,20 +18,20 @@ RSpec.describe EventRouter::DeliveryAdapters::Sidekiq do
       enabled_prefetch_destinations.each do |name, destination|
         serialized_payload = EventRouter.serialize(destination.extra_payload(event))
 
-        expect(EventRouter::DeliveryAdapters::Jobs::SidekiqEventDeliveryJob).to receive(:client_push)
+        expect(EventRouter::DeliveryAdapters::Workers::SidekiqDestinationDeliveryWorker).to receive(:client_push)
           .with(
             'args' => [name, serialized_event, serialized_payload],
-            'class' => EventRouter::DeliveryAdapters::Jobs::SidekiqEventDeliveryJob,
+            'class' => EventRouter::DeliveryAdapters::Workers::SidekiqDestinationDeliveryWorker,
             :queue => adapter_options[:queue],
             :retry => adapter_options[:retry]
           )
       end
 
       disabled_prefetch_destinations.each do |name, _destination|
-        expect(EventRouter::DeliveryAdapters::Jobs::SidekiqEventDeliveryJob).to receive(:client_push)
+        expect(EventRouter::DeliveryAdapters::Workers::SidekiqDestinationDeliveryWorker).to receive(:client_push)
           .with(
             'args' => [name, serialized_event, nil],
-            'class' => EventRouter::DeliveryAdapters::Jobs::SidekiqEventDeliveryJob,
+            'class' => EventRouter::DeliveryAdapters::Workers::SidekiqDestinationDeliveryWorker,
             :queue => adapter_options[:queue],
             :retry => adapter_options[:retry]
           )

--- a/spec/event_router/delivery_adapters/sync_spec.rb
+++ b/spec/event_router/delivery_adapters/sync_spec.rb
@@ -1,10 +1,10 @@
 require 'event_router/delivery_adapters/sync'
 
 RSpec.describe EventRouter::DeliveryAdapters::Sync do
+  let(:event) { DummyEvent.new }
+
   describe '.deliver' do
     subject { described_class.deliver(event) }
-
-    let(:event) { DummyEvent.new }
 
     it 'fetches the extra payload once per destination' do
       event.destinations.each do |_name, destination|
@@ -21,6 +21,22 @@ RSpec.describe EventRouter::DeliveryAdapters::Sync do
       end
 
       subject
+    end
+  end
+
+  describe '.deliver_async' do
+    subject { described_class.deliver_async(event) }
+
+    before { allow(described_class).to receive(:deliver) { true } }
+
+    it 'schedules a thread' do
+      expect(subject).to be_instance_of(Thread)
+    end
+
+    it 'delegates to deliver method' do
+      subject.join
+
+      expect(described_class).to have_received(:deliver).once.with(event)
     end
   end
 end

--- a/spec/event_router/publisher_spec.rb
+++ b/spec/event_router/publisher_spec.rb
@@ -33,4 +33,21 @@ RSpec.describe EventRouter::Publisher do
       subject
     end
   end
+
+  describe '.publish_async' do
+    subject { described_class.publish_async([event, event], adapter: :test_adapter) }
+
+    let(:event) { DummyEvent.new }
+
+    before do
+      allow(EventRouter.configuration).to receive(:delivery_adapter_class) { DummyDeliveryAdapter }
+    end
+
+    it 'delivers the event to the adapter' do
+      expect(EventRouter.configuration).to receive(:delivery_adapter_class).once.with(:test_adapter)
+      expect(DummyDeliveryAdapter).to receive(:deliver_async).twice.with(event)
+
+      subject
+    end
+  end
 end

--- a/spec/event_router_spec.rb
+++ b/spec/event_router_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe EventRouter do
     end
   end
 
+  describe '.publish_async' do
+    subject { EventRouter.publish_async(event) }
+
+    let(:event) { DummyEvent.new }
+
+    it 'delegates to publisher' do
+      expect(EventRouter::Publisher).to receive(:publish_async).once.with(event, adapter: :sync)
+      subject
+    end
+  end
+
   describe '.serialize' do
     subject { EventRouter.serialize(event) }
 


### PR DESCRIPTION
This PR extends `EventRouter` publish API to support publishing events async. Unlike `publish` method, `publish_async` won't block the current thread till the event is published to its destinations. Delivery adapters can support this behaviour by implementing `deliver_async` class method.

### Delivery Adapters

**:sync**

Uses Ruby `Thread` class to deliver the event async to its defined destinations.

**:sidekiq**

Uses a new worker, `SidekiqEventDeliveryWorker` to deliver the event async to its defined destinations.