### PR TITLE
feat: drop active_support dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,27 +2,16 @@ PATH
   remote: .
   specs:
     event_router (0.3.0)
-      activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     ast (2.4.1)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
     diff-lcs (1.3)
-    i18n (1.8.7)
-      concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.14.3)
     oj (3.10.14)
     parallel (1.19.2)
     parser (2.7.1.4)
@@ -67,10 +56,7 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    tzinfo (2.0.4)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/event_router.gemspec
+++ b/event_router.gemspec
@@ -25,9 +25,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # Dependencies
-  spec.add_dependency 'activesupport'
-
   # Development dependencies
   spec.add_development_dependency 'oj'
   spec.add_development_dependency 'pry'

--- a/lib/event_router.rb
+++ b/lib/event_router.rb
@@ -3,12 +3,14 @@
 require 'event_router/version'
 require 'event_router/error'
 
-require 'event_router/event'
-require 'event_router/delivery_adapters/base'
-require 'event_router/serializers/base'
-require 'event_router/publisher'
-require 'event_router/serializer'
 require 'event_router/configuration'
+require 'event_router/event'
+
+require 'event_router/serializers/base'
+require 'event_router/serializer'
+
+require 'event_router/delivery_adapters/base'
+require 'event_router/publisher'
 
 module EventRouter
   module_function

--- a/lib/event_router/delivery_adapters/sidekiq.rb
+++ b/lib/event_router/delivery_adapters/sidekiq.rb
@@ -2,7 +2,6 @@
 
 require 'sidekiq'
 
-require 'event_router/serializer'
 require 'event_router/helpers/event'
 
 require_relative 'helpers/sidekiq'


### PR DESCRIPTION
Drops active support.

1. Replaces `.demodulize.underscore` with a regex `.gsub(/([a-z])([A-Z])/, '\1_\2').gsub(/.*::/, '')` . The regex covers the simple scenarios that most commonly used, e.g "X::Y::FooBoo" -> "foo_boo", "FooBoo" -> "foo_boo"
2. Drops `class_attribute` and replace it with simple class instance variables. On inheritance, the subclasses will inherit all parent options and destinations. Subclasses can extend the settings without affecting the parent event.